### PR TITLE
bulk reactions get wrapper

### DIFF
--- a/model/reaction.go
+++ b/model/reaction.go
@@ -90,3 +90,18 @@ func (o *Reaction) PreSave() {
 		o.CreateAt = GetMillis()
 	}
 }
+
+type PostsReactionsResponseWrapper struct {
+	Content map[string][]*Reaction `json:"content"`
+}
+
+func (o *PostsReactionsResponseWrapper) ToJson() string {
+	b, _ := json.Marshal(o)
+	return string(b)
+}
+
+func PostsReactionsResponseWrapperFromJson(data io.Reader) *PostsReactionsResponseWrapper {
+	var o *PostsReactionsResponseWrapper
+	json.NewDecoder(data).Decode(&o)
+	return o
+}

--- a/model/w_client.go
+++ b/model/w_client.go
@@ -58,6 +58,11 @@ func (c *WClient) GetCreateIntialAdminUrl() string {
 	return fmt.Sprintf("%v/admin/setup/admin", c.ApiUrl)
 }
 
+// Get absolute api url of the posts reactions handle.
+func (c *WClient) GetReactionsForPostsUrl() string {
+	return fmt.Sprintf("%v/posts/ids/reactions", c.ApiUrl)
+}
+
 //
 // METHODS
 //
@@ -134,4 +139,13 @@ func (c *WClient) GetRecentPosts(request *RecentPostsRequestData) (*RecentPostsR
 	}
 	defer closeBody(r)
 	return RecentResponseDataFromJson(r.Body), BuildResponse(r)
+}
+
+func (c *WClient) GetReactionsForPosts(request []string) (*PostsReactionsResponseWrapper, *Response) {
+	r, err := c.MMClient.DoApiPostWithUrl(c.GetReactionsForPostsUrl(), ArrayToJson(request), false)
+	if err != nil {
+		return nil, BuildErrorResponse(r, err)
+	}
+	defer closeBody(r)
+	return PostsReactionsResponseWrapperFromJson(r.Body), BuildResponse(r)
 }


### PR DESCRIPTION
#### Summary

Wrapper for bulk reactions getting. Required because the original handle fails to deserialise on the client side.

#### Ticket Link

<![[--]]
  Fixes [WA-320](https://yt.worldr.com/issue/WA-310)
