### PR TITLE
Improvement/pn token

### DIFF
--- a/api4/w_user.go
+++ b/api4/w_user.go
@@ -2,13 +2,22 @@ package api4
 
 import (
 	"net/http"
+	"time"
 
+	"github.com/mattermost/mattermost-server/v5/app"
+	"github.com/mattermost/mattermost-server/v5/audit"
 	"github.com/mattermost/mattermost-server/v5/model"
+	"github.com/mattermost/mattermost-server/v5/utils"
 )
 
 func (api *API) InitWUser() {
+	// Valid session IS NOT required
 	api.BaseRoutes.WUsers.Handle("/login", api.ApiHandler(loginWrapper)).Methods("POST")
 	api.BaseRoutes.WUsers.Handle("/logout", api.ApiHandler(logout)).Methods("POST")
+
+	// Valid session is required
+	api.BaseRoutes.WPosts.Handle("/sessions/device", api.ApiSessionRequired(attachDevice)).Methods("PUT")
+	api.BaseRoutes.WPosts.Handle("/sessions/device", api.ApiSessionRequired(detachDevice)).Methods("DELETE")
 }
 
 func loginWrapper(c *Context, w http.ResponseWriter, r *http.Request) {
@@ -21,4 +30,69 @@ func loginWrapper(c *Context, w http.ResponseWriter, r *http.Request) {
 		}
 		w.Write([]byte(response.ToJson()))
 	}
+}
+
+func attachDevice(c *Context, w http.ResponseWriter, r *http.Request) {
+	device := model.DeviceFromJson(r.Body)
+
+	if len(device.DeviceId) == 0 {
+		c.SetInvalidParam("device_id")
+		return
+	}
+	if len(device.PushToken) == 0 {
+		c.SetInvalidParam("push_token")
+		return
+	}
+
+	auditRec := c.MakeAuditRecord("attachDevice", audit.Fail)
+	defer c.LogAuditRec(auditRec)
+	auditRec.AddMeta("platform", device.Platform)
+	auditRec.AddMeta("device_id", device.DeviceId)
+	auditRec.AddMeta("push_token", device.PushToken)
+
+	// A special case where we logout of all other sessions with the same device id
+	if err := c.App.RevokeSessionsForDevice(c.App.Session().UserId, device, c.App.Session().Id); err != nil {
+		c.Err = err
+		return
+	}
+
+	c.App.ClearSessionCacheForUser(c.App.Session().UserId)
+	c.App.Session().SetExpireInDays(*c.App.Config().ServiceSettings.SessionLengthMobileInDays)
+
+	maxAge := *c.App.Config().ServiceSettings.SessionLengthMobileInDays * 60 * 60 * 24
+
+	secure := false
+	if app.GetProtocol(r) == "https" {
+		secure = true
+	}
+
+	subpath, _ := utils.GetSubpathFromConfig(c.App.Config())
+
+	expiresAt := time.Unix(model.GetMillis()/1000+int64(maxAge), 0)
+	sessionCookie := &http.Cookie{
+		Name:     model.SESSION_COOKIE_TOKEN,
+		Value:    c.App.Session().Token,
+		Path:     subpath,
+		MaxAge:   maxAge,
+		Expires:  expiresAt,
+		HttpOnly: true,
+		Domain:   c.App.GetCookieDomain(),
+		Secure:   secure,
+	}
+
+	http.SetCookie(w, sessionCookie)
+
+	if err := c.App.AttachDevice(c.App.Session().Id, device, c.App.Session().ExpiresAt); err != nil {
+		c.Err = err
+		return
+	}
+
+	auditRec.Success()
+	c.LogAudit("")
+
+	ReturnStatusOK(w)
+}
+
+func detachDevice(c *Context, w http.ResponseWriter, r *http.Request) {
+
 }

--- a/app/app_iface.go
+++ b/app/app_iface.go
@@ -16,6 +16,7 @@ import (
 	"mime/multipart"
 	"net/http"
 	"net/url"
+	"os"
 	"time"
 
 	"github.com/dyatlov/go-opengraph/opengraph"
@@ -360,7 +361,7 @@ type AppIface interface {
 	AllowOAuthAppAccessToUser(userId string, authRequest *model.AuthorizeRequest) (string, *model.AppError)
 	AssignCategory(channelId string, userId string, category string) (*model.ChannelCategory, *model.AppError)
 	AsymmetricSigningKey() *ecdsa.PrivateKey
-	AttachDeviceId(sessionId string, deviceId string, expiresAt int64) *model.AppError
+	AttachDevice(sessionId string, device *model.Device, expiresAt int64) *model.AppError
 	AttachSessionCookies(w http.ResponseWriter, r *http.Request)
 	AuthenticateUserForLogin(id, loginId, password, mfaToken string, ldapOnly bool) (*model.User, *model.AppError)
 	AuthorizeOAuthUser(w http.ResponseWriter, r *http.Request, service, code, state, redirectUri string) (io.ReadCloser, string, map[string]string, *model.AppError)
@@ -457,6 +458,7 @@ type AppIface interface {
 	DeleteReactionForPost(reaction *model.Reaction) *model.AppError
 	DeleteScheme(schemeId string) (*model.Scheme, *model.AppError)
 	DeleteToken(token *model.Token) *model.AppError
+	DetachDevice(sessionId string) *model.AppError
 	DiagnosticId() string
 	DisableAutoResponder(userId string, asAdmin bool) *model.AppError
 	DisableUserAccessToken(token *model.UserAccessToken) *model.AppError
@@ -464,8 +466,8 @@ type AppIface interface {
 	DoEmojisPermissionsMigration()
 	DoGuestRolesCreationMigration()
 	DoLocalRequest(rawURL string, body []byte) (*http.Response, *model.AppError)
-	DoLogin(w http.ResponseWriter, r *http.Request, user *model.User, deviceId string) *model.AppError
-	DoLoginAdmin(w http.ResponseWriter, r *http.Request, user *model.User, deviceId string) *model.AppError
+	DoLogin(w http.ResponseWriter, r *http.Request, user *model.User, device *model.Device) *model.AppError
+	DoLoginAdmin(w http.ResponseWriter, r *http.Request, user *model.User, device *model.Device) *model.AppError
 	DoPostAction(postId, actionId, userId, selectedOption string) (string, *model.AppError)
 	DoPostActionWithCookie(postId, actionId, userId, selectedOption string, cookie *model.PostActionCookie) (string, *model.AppError)
 	DoUploadFile(now time.Time, rawTeamId string, rawChannelId string, rawUserId string, rawFilename string, data []byte) (*model.FileInfo, *model.AppError)
@@ -624,6 +626,7 @@ type AppIface interface {
 	GetProfileImage(user *model.User) ([]byte, bool, *model.AppError)
 	GetPublicChannelsByIdsForTeam(teamId string, channelIds []string) (*model.ChannelList, *model.AppError)
 	GetPublicChannelsForTeam(teamId string, offset int, limit int) (*model.ChannelList, *model.AppError)
+	GetRandomImageForChannel(imagesFolder string) (*os.File, error)
 	GetReactionsForPost(postId string) ([]*model.Reaction, *model.AppError)
 	GetRecentlyActiveUsersForTeam(teamId string) (map[string]*model.User, *model.AppError)
 	GetRecentlyActiveUsersForTeamPage(teamId string, page, perPage int, asAdmin bool, viewRestrictions *model.ViewUsersRestrictions) ([]*model.User, *model.AppError)
@@ -833,7 +836,7 @@ type AppIface interface {
 	RevokeAllSessions(userId string) *model.AppError
 	RevokeSession(session *model.Session) *model.AppError
 	RevokeSessionById(sessionId string) *model.AppError
-	RevokeSessionsForDeviceId(userId string, deviceId string, currentSessionId string) *model.AppError
+	RevokeSessionsForDevice(userId string, device *model.Device, currentSessionId string) *model.AppError
 	RevokeUserAccessToken(token *model.UserAccessToken) *model.AppError
 	RolesGrantPermission(roleNames []string, permissionId string) bool
 	Saml() einterfaces.SamlInterface

--- a/app/notification_push.go
+++ b/app/notification_push.go
@@ -107,7 +107,7 @@ func (a *App) sendPushNotificationToAllSessions(msg *model.PushNotification, use
 
 		// We made a copy to avoid decoding and parsing all the time
 		tmpMessage := notification
-		tmpMessage.SetDeviceIdAndPlatform(session.DeviceId)
+		tmpMessage.SetDeviceIdAndPlatform(session)
 		tmpMessage.SetServerTag(a.Srv().Config().ServiceSettings.ServerTag)
 		tmpMessage.AckId = model.NewId()
 
@@ -342,7 +342,7 @@ func (a *App) sendToPushProxy(msg model.PushNotification, session *model.Session
 	pushResponse := model.PushResponseFromJson(resp.Body)
 
 	if pushResponse[model.PUSH_STATUS] == model.PUSH_STATUS_REMOVE {
-		a.AttachDeviceId(session.Id, "", session.ExpiresAt)
+		a.DetachDevice(session.Id)
 		a.ClearSessionCacheForUser(session.UserId)
 		return errors.New("Device was reported as removed")
 	}

--- a/app/opentracing_layer.go
+++ b/app/opentracing_layer.go
@@ -16,6 +16,7 @@ import (
 	"mime/multipart"
 	"net/http"
 	"net/url"
+	"os"
 	"time"
 
 	"github.com/dyatlov/go-opengraph/opengraph"
@@ -600,9 +601,9 @@ func (a *OpenTracingAppLayer) AsymmetricSigningKey() *ecdsa.PrivateKey {
 	return resultVar0
 }
 
-func (a *OpenTracingAppLayer) AttachDeviceId(sessionId string, deviceId string, expiresAt int64) *model.AppError {
+func (a *OpenTracingAppLayer) AttachDevice(sessionId string, device *model.Device, expiresAt int64) *model.AppError {
 	origCtx := a.ctx
-	span, newCtx := tracing.StartSpanWithParentByContext(a.ctx, "app.AttachDeviceId")
+	span, newCtx := tracing.StartSpanWithParentByContext(a.ctx, "app.AttachDevice")
 
 	a.ctx = newCtx
 	a.app.Srv().Store.SetContext(newCtx)
@@ -612,7 +613,7 @@ func (a *OpenTracingAppLayer) AttachDeviceId(sessionId string, deviceId string, 
 	}()
 
 	defer span.Finish()
-	resultVar0 := a.app.AttachDeviceId(sessionId, deviceId, expiresAt)
+	resultVar0 := a.app.AttachDevice(sessionId, device, expiresAt)
 
 	if resultVar0 != nil {
 		span.LogFields(spanlog.Error(resultVar0))
@@ -2924,6 +2925,28 @@ func (a *OpenTracingAppLayer) DemoteUserToGuest(user *model.User) *model.AppErro
 	return resultVar0
 }
 
+func (a *OpenTracingAppLayer) DetachDevice(sessionId string) *model.AppError {
+	origCtx := a.ctx
+	span, newCtx := tracing.StartSpanWithParentByContext(a.ctx, "app.DetachDevice")
+
+	a.ctx = newCtx
+	a.app.Srv().Store.SetContext(newCtx)
+	defer func() {
+		a.app.Srv().Store.SetContext(origCtx)
+		a.ctx = origCtx
+	}()
+
+	defer span.Finish()
+	resultVar0 := a.app.DetachDevice(sessionId)
+
+	if resultVar0 != nil {
+		span.LogFields(spanlog.Error(resultVar0))
+		ext.Error.Set(span, true)
+	}
+
+	return resultVar0
+}
+
 func (a *OpenTracingAppLayer) DiagnosticId() string {
 	origCtx := a.ctx
 	span, newCtx := tracing.StartSpanWithParentByContext(a.ctx, "app.DiagnosticId")
@@ -3111,7 +3134,7 @@ func (a *OpenTracingAppLayer) DoLocalRequest(rawURL string, body []byte) (*http.
 	return resultVar0, resultVar1
 }
 
-func (a *OpenTracingAppLayer) DoLogin(w http.ResponseWriter, r *http.Request, user *model.User, deviceId string) *model.AppError {
+func (a *OpenTracingAppLayer) DoLogin(w http.ResponseWriter, r *http.Request, user *model.User, device *model.Device) *model.AppError {
 	origCtx := a.ctx
 	span, newCtx := tracing.StartSpanWithParentByContext(a.ctx, "app.DoLogin")
 
@@ -3123,7 +3146,7 @@ func (a *OpenTracingAppLayer) DoLogin(w http.ResponseWriter, r *http.Request, us
 	}()
 
 	defer span.Finish()
-	resultVar0 := a.app.DoLogin(w, r, user, deviceId)
+	resultVar0 := a.app.DoLogin(w, r, user, device)
 
 	if resultVar0 != nil {
 		span.LogFields(spanlog.Error(resultVar0))
@@ -3133,7 +3156,7 @@ func (a *OpenTracingAppLayer) DoLogin(w http.ResponseWriter, r *http.Request, us
 	return resultVar0
 }
 
-func (a *OpenTracingAppLayer) DoLoginAdmin(w http.ResponseWriter, r *http.Request, user *model.User, deviceId string) *model.AppError {
+func (a *OpenTracingAppLayer) DoLoginAdmin(w http.ResponseWriter, r *http.Request, user *model.User, device *model.Device) *model.AppError {
 	origCtx := a.ctx
 	span, newCtx := tracing.StartSpanWithParentByContext(a.ctx, "app.DoLoginAdmin")
 
@@ -3145,7 +3168,7 @@ func (a *OpenTracingAppLayer) DoLoginAdmin(w http.ResponseWriter, r *http.Reques
 	}()
 
 	defer span.Finish()
-	resultVar0 := a.app.DoLoginAdmin(w, r, user, deviceId)
+	resultVar0 := a.app.DoLoginAdmin(w, r, user, device)
 
 	if resultVar0 != nil {
 		span.LogFields(spanlog.Error(resultVar0))
@@ -7155,6 +7178,23 @@ func (a *OpenTracingAppLayer) GetPublicKey(name string) ([]byte, *model.AppError
 		span.LogFields(spanlog.Error(resultVar1))
 		ext.Error.Set(span, true)
 	}
+
+	return resultVar0, resultVar1
+}
+
+func (a *OpenTracingAppLayer) GetRandomImageForChannel(imagesFolder string) (*os.File, error) {
+	origCtx := a.ctx
+	span, newCtx := tracing.StartSpanWithParentByContext(a.ctx, "app.GetRandomImageForChannel")
+
+	a.ctx = newCtx
+	a.app.Srv().Store.SetContext(newCtx)
+	defer func() {
+		a.app.Srv().Store.SetContext(origCtx)
+		a.ctx = origCtx
+	}()
+
+	defer span.Finish()
+	resultVar0, resultVar1 := a.app.GetRandomImageForChannel(imagesFolder)
 
 	return resultVar0, resultVar1
 }
@@ -11729,9 +11769,9 @@ func (a *OpenTracingAppLayer) RevokeSessionById(sessionId string) *model.AppErro
 	return resultVar0
 }
 
-func (a *OpenTracingAppLayer) RevokeSessionsForDeviceId(userId string, deviceId string, currentSessionId string) *model.AppError {
+func (a *OpenTracingAppLayer) RevokeSessionsForDevice(userId string, device *model.Device, currentSessionId string) *model.AppError {
 	origCtx := a.ctx
-	span, newCtx := tracing.StartSpanWithParentByContext(a.ctx, "app.RevokeSessionsForDeviceId")
+	span, newCtx := tracing.StartSpanWithParentByContext(a.ctx, "app.RevokeSessionsForDevice")
 
 	a.ctx = newCtx
 	a.app.Srv().Store.SetContext(newCtx)
@@ -11741,7 +11781,7 @@ func (a *OpenTracingAppLayer) RevokeSessionsForDeviceId(userId string, deviceId 
 	}()
 
 	defer span.Finish()
-	resultVar0 := a.app.RevokeSessionsForDeviceId(userId, deviceId, currentSessionId)
+	resultVar0 := a.app.RevokeSessionsForDevice(userId, device, currentSessionId)
 
 	if resultVar0 != nil {
 		span.LogFields(spanlog.Error(resultVar0))

--- a/app/plugin_hooks_test.go
+++ b/app/plugin_hooks_test.go
@@ -696,7 +696,7 @@ func TestUserWillLogIn_Blocked(t *testing.T) {
 
 	r := &http.Request{}
 	w := httptest.NewRecorder()
-	err = th.App.DoLogin(w, r, th.BasicUser, "")
+	err = th.App.DoLogin(w, r, th.BasicUser, model.MockDevice)
 
 	assert.Contains(t, err.Id, "Login rejected by plugin", "Expected Login rejected by plugin, got %s", err.Id)
 }
@@ -735,7 +735,7 @@ func TestUserWillLogInIn_Passed(t *testing.T) {
 
 	r := &http.Request{}
 	w := httptest.NewRecorder()
-	err = th.App.DoLogin(w, r, th.BasicUser, "")
+	err = th.App.DoLogin(w, r, th.BasicUser, model.MockDevice)
 
 	assert.Nil(t, err, "Expected nil, got %s", err)
 	assert.Equal(t, th.App.Session().UserId, th.BasicUser.Id)
@@ -776,7 +776,7 @@ func TestUserHasLoggedIn(t *testing.T) {
 
 	r := &http.Request{}
 	w := httptest.NewRecorder()
-	err = th.App.DoLogin(w, r, th.BasicUser, "")
+	err = th.App.DoLogin(w, r, th.BasicUser, model.MockDevice)
 
 	assert.Nil(t, err, "Expected nil, got %s", err)
 

--- a/model/device.go
+++ b/model/device.go
@@ -1,0 +1,29 @@
+package model
+
+import (
+	"encoding/json"
+	"io"
+)
+
+type Device struct {
+	Platform  string `json:"platform"`
+	DeviceId  string `json:"device_id"`
+	PushToken string `json:"push_token"`
+}
+
+func (o *Device) ToJson() string {
+	b, _ := json.Marshal(o)
+	return string(b)
+}
+
+func DeviceFromJson(data io.Reader) *Device {
+	var o *Device
+	json.NewDecoder(data).Decode(&o)
+	return o
+}
+
+var MockDevice = &Device{
+	Platform:  "apple",
+	DeviceId:  "1234567890",
+	PushToken: "12345678901234567890",
+}

--- a/model/login_data.go
+++ b/model/login_data.go
@@ -1,0 +1,30 @@
+package model
+
+import (
+	"encoding/json"
+	"io"
+)
+
+type LoginData struct {
+	LoginId            string  `json:"login_id"`
+	Password           string  `json:"password"`
+	Device             *Device `json:"device"`
+	Id                 string  `json:"id"`
+	MfaToken           string  `json:"token"`
+	LdapOnly           bool    `json:"ldap_only"`
+	UseAdminSessionTtl bool
+}
+
+func (o *LoginData) ToJson() string {
+	b, _ := json.Marshal(o)
+	return string(b)
+}
+
+func LoginDataFromJson(data io.Reader) (*LoginData, error) {
+	var o *LoginData
+	if err := json.NewDecoder(data).Decode(&o); err != nil {
+		return nil, err
+	} else {
+		return o, nil
+	}
+}

--- a/model/push_notification.go
+++ b/model/push_notification.go
@@ -7,7 +7,6 @@ import (
 	"encoding/json"
 	"errors"
 	"io"
-	"strings"
 )
 
 const (
@@ -49,7 +48,7 @@ type PushNotification struct {
 	Platform         string `json:"platform"`
 	ServerTag        string `json:"server_tag"`
 	ServerId         string `json:"server_id"`
-	DeviceId         string `json:"device_id"`
+	DeviceId         string `json:"device_id"` // This is a push token really, not a device id. Leaving as is for now to avoid changing push proxy.
 	PostId           string `json:"post_id"`
 	Category         string `json:"category,omitempty"`
 	Sound            string `json:"sound,omitempty"`
@@ -76,14 +75,9 @@ func (me *PushNotification) ToJson() string {
 	return string(b)
 }
 
-func (me *PushNotification) SetDeviceIdAndPlatform(deviceId string) {
-
-	index := strings.Index(deviceId, ":")
-
-	if index > -1 {
-		me.Platform = deviceId[:index]
-		me.DeviceId = deviceId[index+1:]
-	}
+func (me *PushNotification) SetDeviceIdAndPlatform(session *Session) {
+	me.Platform = session.Platform
+	me.DeviceId = session.PushToken // Firebase-provided push token identifies the device
 }
 
 func (me *PushNotification) SetServerTag(tag *string) {

--- a/model/push_notification_test.go
+++ b/model/push_notification_test.go
@@ -56,53 +56,6 @@ func TestPushNotificationAck(t *testing.T) {
 	})
 }
 
-func TestPushNotificationDeviceId(t *testing.T) {
-
-	msg := PushNotification{Platform: "test"}
-
-	msg.SetDeviceIdAndPlatform("android:12345")
-	require.Equal(t, msg.Platform, "android", msg.Platform)
-	require.Equal(t, msg.DeviceId, "12345", msg.DeviceId)
-	msg.Platform = ""
-	msg.DeviceId = ""
-
-	msg.SetDeviceIdAndPlatform("android:12:345")
-	require.Equal(t, msg.Platform, "android", msg.Platform)
-	require.Equal(t, msg.DeviceId, "12:345", msg.DeviceId)
-	msg.Platform = ""
-	msg.DeviceId = ""
-
-	msg.SetDeviceIdAndPlatform("android::12345")
-	require.Equal(t, msg.Platform, "android", msg.Platform)
-	require.Equal(t, msg.DeviceId, ":12345", msg.DeviceId)
-	msg.Platform = ""
-	msg.DeviceId = ""
-
-	msg.SetDeviceIdAndPlatform(":12345")
-	require.Equal(t, msg.Platform, "", msg.Platform)
-	require.Equal(t, msg.DeviceId, "12345", msg.DeviceId)
-	msg.Platform = ""
-	msg.DeviceId = ""
-
-	msg.SetDeviceIdAndPlatform("android:")
-	require.Equal(t, msg.Platform, "android", msg.Platform)
-	require.Equal(t, msg.DeviceId, "", msg.DeviceId)
-	msg.Platform = ""
-	msg.DeviceId = ""
-
-	msg.SetDeviceIdAndPlatform("")
-	require.Equal(t, msg.Platform, "", msg.Platform)
-	require.Equal(t, msg.DeviceId, "", msg.DeviceId)
-	msg.Platform = ""
-	msg.DeviceId = ""
-
-	msg.SetDeviceIdAndPlatform(":")
-	require.Equal(t, msg.Platform, "", msg.Platform)
-	require.Equal(t, msg.DeviceId, "", msg.DeviceId)
-	msg.Platform = ""
-	msg.DeviceId = ""
-}
-
 func TestPushNotificationServerTag(t *testing.T) {
 
 	msg := PushNotification{ServerTag: "test"}

--- a/model/session.go
+++ b/model/session.go
@@ -39,6 +39,8 @@ type Session struct {
 	IsOAuth        bool          `json:"is_oauth"`
 	Props          StringMap     `json:"props"`
 	TeamMembers    []*TeamMember `json:"team_members" db:"-"`
+	Platform       string        `json:"platform"`
+	PushToken      string        `json:"push_token"`
 }
 
 func (me *Session) DeepCopy() *Session {

--- a/model/version.go
+++ b/model/version.go
@@ -13,6 +13,7 @@ import (
 // It should be maintained in chronological order with most current
 // release at the front of the list.
 var versions = []string{
+	"6.1.0", // modified sessions table
 	"6.0.0", // Worldr starts here
 	"5.22.0",
 	"5.21.0",

--- a/scripts/worldr-postgresql-1.0.sql
+++ b/scripts/worldr-postgresql-1.0.sql
@@ -601,7 +601,8 @@ CREATE TABLE public.sessions (
     deviceid character varying(512),
     roles character varying(64),
     isoauth boolean,
-    props character varying(1000)
+    platform character varying(64),
+    pushtoken character varying(512)
 );
 
 

--- a/store/opentracing_layer.go
+++ b/store/opentracing_layer.go
@@ -5832,6 +5832,24 @@ func (s *OpenTracingLayerSessionStore) GetSessionsWithDeviceId(userId string, de
 	return resultVar0, resultVar1
 }
 
+func (s *OpenTracingLayerSessionStore) GetSessionsWithPushToken(userId string, pushToken string) ([]*model.Session, *model.AppError) {
+	origCtx := s.Root.Store.Context()
+	span, newCtx := tracing.StartSpanWithParentByContext(s.Root.Store.Context(), "SessionStore.GetSessionsWithPushToken")
+	s.Root.Store.SetContext(newCtx)
+	defer func() {
+		s.Root.Store.SetContext(origCtx)
+	}()
+
+	defer span.Finish()
+	resultVar0, resultVar1 := s.SessionStore.GetSessionsWithPushToken(userId, pushToken)
+	if resultVar1 != nil {
+		span.LogFields(spanlog.Error(resultVar1))
+		ext.Error.Set(span, true)
+	}
+
+	return resultVar0, resultVar1
+}
+
 func (s *OpenTracingLayerSessionStore) PermanentDeleteSessionsByUser(teamId string) *model.AppError {
 	origCtx := s.Root.Store.Context()
 	span, newCtx := tracing.StartSpanWithParentByContext(s.Root.Store.Context(), "SessionStore.PermanentDeleteSessionsByUser")
@@ -5886,6 +5904,24 @@ func (s *OpenTracingLayerSessionStore) RemoveAllSessions() *model.AppError {
 	return resultVar0
 }
 
+func (s *OpenTracingLayerSessionStore) RemovePushToken(id string) *model.AppError {
+	origCtx := s.Root.Store.Context()
+	span, newCtx := tracing.StartSpanWithParentByContext(s.Root.Store.Context(), "SessionStore.RemovePushToken")
+	s.Root.Store.SetContext(newCtx)
+	defer func() {
+		s.Root.Store.SetContext(origCtx)
+	}()
+
+	defer span.Finish()
+	resultVar0 := s.SessionStore.RemovePushToken(id)
+	if resultVar0 != nil {
+		span.LogFields(spanlog.Error(resultVar0))
+		ext.Error.Set(span, true)
+	}
+
+	return resultVar0
+}
+
 func (s *OpenTracingLayerSessionStore) Save(session *model.Session) (*model.Session, *model.AppError) {
 	origCtx := s.Root.Store.Context()
 	span, newCtx := tracing.StartSpanWithParentByContext(s.Root.Store.Context(), "SessionStore.Save")
@@ -5904,22 +5940,22 @@ func (s *OpenTracingLayerSessionStore) Save(session *model.Session) (*model.Sess
 	return resultVar0, resultVar1
 }
 
-func (s *OpenTracingLayerSessionStore) UpdateDeviceId(id string, deviceId string, expiresAt int64) (string, *model.AppError) {
+func (s *OpenTracingLayerSessionStore) UpdateDevice(id string, device *model.Device, expiresAt int64) *model.AppError {
 	origCtx := s.Root.Store.Context()
-	span, newCtx := tracing.StartSpanWithParentByContext(s.Root.Store.Context(), "SessionStore.UpdateDeviceId")
+	span, newCtx := tracing.StartSpanWithParentByContext(s.Root.Store.Context(), "SessionStore.UpdateDevice")
 	s.Root.Store.SetContext(newCtx)
 	defer func() {
 		s.Root.Store.SetContext(origCtx)
 	}()
 
 	defer span.Finish()
-	resultVar0, resultVar1 := s.SessionStore.UpdateDeviceId(id, deviceId, expiresAt)
-	if resultVar1 != nil {
-		span.LogFields(spanlog.Error(resultVar1))
+	resultVar0 := s.SessionStore.UpdateDevice(id, device, expiresAt)
+	if resultVar0 != nil {
+		span.LogFields(spanlog.Error(resultVar0))
 		ext.Error.Set(span, true)
 	}
 
-	return resultVar0, resultVar1
+	return resultVar0
 }
 
 func (s *OpenTracingLayerSessionStore) UpdateLastActivityAt(sessionId string, time int64) *model.AppError {

--- a/store/sqlstore/upgrade.go
+++ b/store/sqlstore/upgrade.go
@@ -96,7 +96,6 @@ func saveSchemaVersion(sqlStore SqlStore, version string) {
 func shouldPerformUpgrade(sqlStore SqlStore, currentSchemaVersion string, expectedSchemaVersion string) bool {
 	if sqlStore.GetCurrentSchemaVersion() == currentSchemaVersion {
 		mlog.Warn("Attempting to upgrade the database schema version", mlog.String("current_version", currentSchemaVersion), mlog.String("new_version", expectedSchemaVersion))
-
 		return true
 	}
 

--- a/store/sqlstore/upgrade_test.go
+++ b/store/sqlstore/upgrade_test.go
@@ -21,20 +21,20 @@ func TestStoreUpgrade(t *testing.T) {
 
 		t.Run("upgrade from invalid version", func(t *testing.T) {
 			saveSchemaVersion(sqlStore, "invalid")
-			err := upgradeDatabase(sqlStore, "5.8.0")
+			err := upgradeDatabase(sqlStore, "6.0.0")
 			require.EqualError(t, err, "failed to parse database schema version invalid: No Major.Minor.Patch elements found")
 			require.Equal(t, "invalid", sqlStore.GetCurrentSchemaVersion())
 		})
 
 		t.Run("upgrade from unsupported version", func(t *testing.T) {
-			saveSchemaVersion(sqlStore, "2.0.0")
-			err := upgradeDatabase(sqlStore, "5.8.0")
-			require.EqualError(t, err, "Database schema version 2.0.0 is no longer supported. This Mattermost server supports automatic upgrades from schema version 3.0.0 through schema version 5.8.0. Please manually upgrade to at least version 3.0.0 before continuing.")
-			require.Equal(t, "2.0.0", sqlStore.GetCurrentSchemaVersion())
+			saveSchemaVersion(sqlStore, "5.8.0")
+			err := upgradeDatabase(sqlStore, "6.0.0")
+			require.EqualError(t, err, "Database schema version 5.x.x is no longer supported. Please manually upgrade to at least version 6.0.0 before continuing.")
+			require.Equal(t, "5.8.0", sqlStore.GetCurrentSchemaVersion())
 		})
 
 		t.Run("upgrade from earliest supported version", func(t *testing.T) {
-			saveSchemaVersion(sqlStore, VERSION_3_0_0)
+			saveSchemaVersion(sqlStore, VERSION_6_0_0)
 			err := upgradeDatabase(sqlStore, CURRENT_SCHEMA_VERSION)
 			require.NoError(t, err)
 			require.Equal(t, CURRENT_SCHEMA_VERSION, sqlStore.GetCurrentSchemaVersion())
@@ -47,36 +47,35 @@ func TestStoreUpgrade(t *testing.T) {
 			require.Equal(t, CURRENT_SCHEMA_VERSION, sqlStore.GetCurrentSchemaVersion())
 		})
 
-		t.Run("upgrade schema running earlier minor version", func(t *testing.T) {
-			saveSchemaVersion(sqlStore, "5.1.0")
-			err := upgradeDatabase(sqlStore, "5.8.0")
-			require.NoError(t, err)
-			// Assert CURRENT_SCHEMA_VERSION, not 5.8.0, since the migrations will move
-			// past 5.8.0 regardless of the input parameter.
-			require.Equal(t, CURRENT_SCHEMA_VERSION, sqlStore.GetCurrentSchemaVersion())
-		})
+		// TODO: This test is irrelevant to Worldr. Add it back when we have a new minor version.
+		// t.Run("upgrade schema running earlier minor version", func(t *testing.T) {
+		// 	saveSchemaVersion(sqlStore, "6.0.0")
+		// 	err := upgradeDatabase(sqlStore, "6.1.0")
+		// 	require.NoError(t, err)
+		// 	// The migrations will move past 6.1.0 regardless of the input parameter.
+		// 	require.Equal(t, CURRENT_SCHEMA_VERSION, sqlStore.GetCurrentSchemaVersion())
+		// })
 
 		t.Run("upgrade schema running later minor version", func(t *testing.T) {
-			saveSchemaVersion(sqlStore, "5.29.0")
-			err := upgradeDatabase(sqlStore, "5.8.0")
+			saveSchemaVersion(sqlStore, "6.0.0")
+			err := upgradeDatabase(sqlStore, "6.1.0")
 			require.NoError(t, err)
-			//require.Equal(t, "5.29.0", sqlStore.GetCurrentSchemaVersion())
-			require.Equal(t, "6.0.0", sqlStore.GetCurrentSchemaVersion())
-			// Worldr does not use 5.29.0.
+			require.Equal(t, "6.1.0", sqlStore.GetCurrentSchemaVersion())
 		})
 
-		t.Run("upgrade schema running earlier major version", func(t *testing.T) {
-			saveSchemaVersion(sqlStore, "4.1.0")
-			err := upgradeDatabase(sqlStore, CURRENT_SCHEMA_VERSION)
-			require.NoError(t, err)
-			require.Equal(t, CURRENT_SCHEMA_VERSION, sqlStore.GetCurrentSchemaVersion())
-		})
+		// TODO: This test is irrelevant to Worldr. Add it back when we have a new major version.
+		// t.Run("upgrade schema running earlier major version", func(t *testing.T) {
+		// 	saveSchemaVersion(sqlStore, "4.1.0")
+		// 	err := upgradeDatabase(sqlStore, CURRENT_SCHEMA_VERSION)
+		// 	require.NoError(t, err)
+		// 	require.Equal(t, CURRENT_SCHEMA_VERSION, sqlStore.GetCurrentSchemaVersion())
+		// })
 
 		t.Run("upgrade schema running later major version", func(t *testing.T) {
-			saveSchemaVersion(sqlStore, "6.0.0")
-			err := upgradeDatabase(sqlStore, "5.8.0")
-			require.EqualError(t, err, "Database schema version 6.0.0 is not supported. This Mattermost server supports only >=5.8.0, <6.0.0. Please upgrade to at least version 6.0.0 before continuing.")
-			require.Equal(t, "6.0.0", sqlStore.GetCurrentSchemaVersion())
+			saveSchemaVersion(sqlStore, "6.1.0")
+			err := upgradeDatabase(sqlStore, "7.1.0")
+			require.EqualError(t, err, "Database schema version 7.1.0 is not supported. Please upgrade to at least version 7.0.0 before continuing.")
+			require.Equal(t, "6.1.0", sqlStore.GetCurrentSchemaVersion())
 		})
 	})
 }
@@ -85,14 +84,14 @@ func TestSaveSchemaVersion(t *testing.T) {
 	StoreTest(t, func(t *testing.T, ss store.Store) {
 		sqlStore := ss.(SqlStore)
 
-		// t.Run("set earliest version", func(t *testing.T) {
-		// 	saveSchemaVersion(sqlStore, VERSION_3_0_0)
-		// 	props, err := ss.System().Get()
-		// 	require.Nil(t, err)
+		t.Run("set earliest version", func(t *testing.T) {
+			saveSchemaVersion(sqlStore, OLDEST_SUPPORTED_VERSION)
+			props, err := ss.System().Get()
+			require.Nil(t, err)
 
-		// 	require.Equal(t, VERSION_3_0_0, props["Version"])
-		// 	require.Equal(t, VERSION_3_0_0, sqlStore.GetCurrentSchemaVersion())
-		// })
+			require.Equal(t, OLDEST_SUPPORTED_VERSION, props["Version"])
+			require.Equal(t, OLDEST_SUPPORTED_VERSION, sqlStore.GetCurrentSchemaVersion())
+		})
 
 		t.Run("set current version", func(t *testing.T) {
 			saveSchemaVersion(sqlStore, CURRENT_SCHEMA_VERSION)

--- a/store/store.go
+++ b/store/store.go
@@ -364,11 +364,13 @@ type SessionStore interface {
 	PermanentDeleteSessionsByUser(teamId string) *model.AppError
 	UpdateLastActivityAt(sessionId string, time int64) *model.AppError
 	UpdateRoles(userId string, roles string) (string, *model.AppError)
-	UpdateDeviceId(id string, deviceId string, expiresAt int64) (string, *model.AppError)
+	UpdateDevice(id string, device *model.Device, expiresAt int64) *model.AppError
+	RemovePushToken(id string) *model.AppError
 	UpdateProps(session *model.Session) *model.AppError
 	AnalyticsSessionCount() (int64, *model.AppError)
 	Cleanup(expiryTime int64, batchSize int64)
 	GetSessionsWithDeviceId(userId string, deviceId string) ([]*model.Session, *model.AppError)
+	GetSessionsWithPushToken(userId string, pushToken string) ([]*model.Session, *model.AppError)
 }
 
 type AuditStore interface {

--- a/store/storetest/mocks/SessionStore.go
+++ b/store/storetest/mocks/SessionStore.go
@@ -142,6 +142,31 @@ func (_m *SessionStore) GetSessionsWithDeviceId(userId string, deviceId string) 
 	return r0, r1
 }
 
+// GetSessionsWithPushToken provides a mock function with given fields: userId, pushToken
+func (_m *SessionStore) GetSessionsWithPushToken(userId string, pushToken string) ([]*model.Session, *model.AppError) {
+	ret := _m.Called(userId, pushToken)
+
+	var r0 []*model.Session
+	if rf, ok := ret.Get(0).(func(string, string) []*model.Session); ok {
+		r0 = rf(userId, pushToken)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).([]*model.Session)
+		}
+	}
+
+	var r1 *model.AppError
+	if rf, ok := ret.Get(1).(func(string, string) *model.AppError); ok {
+		r1 = rf(userId, pushToken)
+	} else {
+		if ret.Get(1) != nil {
+			r1 = ret.Get(1).(*model.AppError)
+		}
+	}
+
+	return r0, r1
+}
+
 // PermanentDeleteSessionsByUser provides a mock function with given fields: teamId
 func (_m *SessionStore) PermanentDeleteSessionsByUser(teamId string) *model.AppError {
 	ret := _m.Called(teamId)
@@ -190,6 +215,22 @@ func (_m *SessionStore) RemoveAllSessions() *model.AppError {
 	return r0
 }
 
+// RemovePushToken provides a mock function with given fields: id
+func (_m *SessionStore) RemovePushToken(id string) *model.AppError {
+	ret := _m.Called(id)
+
+	var r0 *model.AppError
+	if rf, ok := ret.Get(0).(func(string) *model.AppError); ok {
+		r0 = rf(id)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(*model.AppError)
+		}
+	}
+
+	return r0
+}
+
 // Save provides a mock function with given fields: session
 func (_m *SessionStore) Save(session *model.Session) (*model.Session, *model.AppError) {
 	ret := _m.Called(session)
@@ -215,27 +256,20 @@ func (_m *SessionStore) Save(session *model.Session) (*model.Session, *model.App
 	return r0, r1
 }
 
-// UpdateDeviceId provides a mock function with given fields: id, deviceId, expiresAt
-func (_m *SessionStore) UpdateDeviceId(id string, deviceId string, expiresAt int64) (string, *model.AppError) {
-	ret := _m.Called(id, deviceId, expiresAt)
+// UpdateDevice provides a mock function with given fields: id, device, expiresAt
+func (_m *SessionStore) UpdateDevice(id string, device *model.Device, expiresAt int64) *model.AppError {
+	ret := _m.Called(id, device, expiresAt)
 
-	var r0 string
-	if rf, ok := ret.Get(0).(func(string, string, int64) string); ok {
-		r0 = rf(id, deviceId, expiresAt)
+	var r0 *model.AppError
+	if rf, ok := ret.Get(0).(func(string, *model.Device, int64) *model.AppError); ok {
+		r0 = rf(id, device, expiresAt)
 	} else {
-		r0 = ret.Get(0).(string)
-	}
-
-	var r1 *model.AppError
-	if rf, ok := ret.Get(1).(func(string, string, int64) *model.AppError); ok {
-		r1 = rf(id, deviceId, expiresAt)
-	} else {
-		if ret.Get(1) != nil {
-			r1 = ret.Get(1).(*model.AppError)
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(*model.AppError)
 		}
 	}
 
-	return r0, r1
+	return r0
 }
 
 // UpdateLastActivityAt provides a mock function with given fields: sessionId, time

--- a/store/storetest/session_store.go
+++ b/store/storetest/session_store.go
@@ -176,10 +176,16 @@ func testSessionUpdateDeviceId(t *testing.T, ss store.Store) {
 	s1 := &model.Session{}
 	s1.UserId = model.NewId()
 
+	d := &model.Device{
+		Platform:  model.PUSH_NOTIFY_APPLE,
+		PushToken: "1234567890",
+		DeviceId:  "111",
+	}
+
 	s1, err := ss.Session().Save(s1)
 	require.Nil(t, err)
 
-	_, err = ss.Session().UpdateDeviceId(s1.Id, model.PUSH_NOTIFY_APPLE+":1234567890", s1.ExpiresAt)
+	err = ss.Session().UpdateDevice(s1.Id, d, s1.ExpiresAt)
 	require.Nil(t, err)
 
 	s2 := &model.Session{}
@@ -188,7 +194,7 @@ func testSessionUpdateDeviceId(t *testing.T, ss store.Store) {
 	s2, err = ss.Session().Save(s2)
 	require.Nil(t, err)
 
-	_, err = ss.Session().UpdateDeviceId(s2.Id, model.PUSH_NOTIFY_APPLE+":1234567890", s1.ExpiresAt)
+	err = ss.Session().UpdateDevice(s2.Id, d, s1.ExpiresAt)
 	require.Nil(t, err)
 }
 
@@ -196,10 +202,16 @@ func testSessionUpdateDeviceId2(t *testing.T, ss store.Store) {
 	s1 := &model.Session{}
 	s1.UserId = model.NewId()
 
+	d := &model.Device{
+		Platform:  model.PUSH_NOTIFY_ANDROID,
+		PushToken: "1234567890",
+		DeviceId:  "111",
+	}
+
 	s1, err := ss.Session().Save(s1)
 	require.Nil(t, err)
 
-	_, err = ss.Session().UpdateDeviceId(s1.Id, model.PUSH_NOTIFY_APPLE_REACT_NATIVE+":1234567890", s1.ExpiresAt)
+	err = ss.Session().UpdateDevice(s1.Id, d, s1.ExpiresAt)
 	require.Nil(t, err)
 
 	s2 := &model.Session{}
@@ -208,7 +220,7 @@ func testSessionUpdateDeviceId2(t *testing.T, ss store.Store) {
 	s2, err = ss.Session().Save(s2)
 	require.Nil(t, err)
 
-	_, err = ss.Session().UpdateDeviceId(s2.Id, model.PUSH_NOTIFY_APPLE_REACT_NATIVE+":1234567890", s1.ExpiresAt)
+	err = ss.Session().UpdateDevice(s2.Id, d, s1.ExpiresAt)
 	require.Nil(t, err)
 }
 

--- a/store/timer_layer.go
+++ b/store/timer_layer.go
@@ -5285,6 +5285,22 @@ func (s *TimerLayerSessionStore) GetSessionsWithDeviceId(userId string, deviceId
 	return resultVar0, resultVar1
 }
 
+func (s *TimerLayerSessionStore) GetSessionsWithPushToken(userId string, pushToken string) ([]*model.Session, *model.AppError) {
+	start := timemodule.Now()
+
+	resultVar0, resultVar1 := s.SessionStore.GetSessionsWithPushToken(userId, pushToken)
+
+	elapsed := float64(timemodule.Since(start)) / float64(timemodule.Second)
+	if s.Root.Metrics != nil {
+		success := "false"
+		if resultVar1 == nil {
+			success = "true"
+		}
+		s.Root.Metrics.ObserveStoreMethodDuration("SessionStore.GetSessionsWithPushToken", success, elapsed)
+	}
+	return resultVar0, resultVar1
+}
+
 func (s *TimerLayerSessionStore) PermanentDeleteSessionsByUser(teamId string) *model.AppError {
 	start := timemodule.Now()
 
@@ -5333,6 +5349,22 @@ func (s *TimerLayerSessionStore) RemoveAllSessions() *model.AppError {
 	return resultVar0
 }
 
+func (s *TimerLayerSessionStore) RemovePushToken(id string) *model.AppError {
+	start := timemodule.Now()
+
+	resultVar0 := s.SessionStore.RemovePushToken(id)
+
+	elapsed := float64(timemodule.Since(start)) / float64(timemodule.Second)
+	if s.Root.Metrics != nil {
+		success := "false"
+		if resultVar0 == nil {
+			success = "true"
+		}
+		s.Root.Metrics.ObserveStoreMethodDuration("SessionStore.RemovePushToken", success, elapsed)
+	}
+	return resultVar0
+}
+
 func (s *TimerLayerSessionStore) Save(session *model.Session) (*model.Session, *model.AppError) {
 	start := timemodule.Now()
 
@@ -5349,20 +5381,20 @@ func (s *TimerLayerSessionStore) Save(session *model.Session) (*model.Session, *
 	return resultVar0, resultVar1
 }
 
-func (s *TimerLayerSessionStore) UpdateDeviceId(id string, deviceId string, expiresAt int64) (string, *model.AppError) {
+func (s *TimerLayerSessionStore) UpdateDevice(id string, device *model.Device, expiresAt int64) *model.AppError {
 	start := timemodule.Now()
 
-	resultVar0, resultVar1 := s.SessionStore.UpdateDeviceId(id, deviceId, expiresAt)
+	resultVar0 := s.SessionStore.UpdateDevice(id, device, expiresAt)
 
 	elapsed := float64(timemodule.Since(start)) / float64(timemodule.Second)
 	if s.Root.Metrics != nil {
 		success := "false"
-		if resultVar1 == nil {
+		if resultVar0 == nil {
 			success = "true"
 		}
-		s.Root.Metrics.ObserveStoreMethodDuration("SessionStore.UpdateDeviceId", success, elapsed)
+		s.Root.Metrics.ObserveStoreMethodDuration("SessionStore.UpdateDevice", success, elapsed)
 	}
-	return resultVar0, resultVar1
+	return resultVar0
 }
 
 func (s *TimerLayerSessionStore) UpdateLastActivityAt(sessionId string, time int64) *model.AppError {

--- a/web/oauth.go
+++ b/web/oauth.go
@@ -297,7 +297,7 @@ func completeOAuth(c *Context, w http.ResponseWriter, r *http.Request) {
 	} else if action == model.OAUTH_ACTION_SSO_TO_EMAIL {
 		redirectUrl = app.GetProtocol(r) + "://" + r.Host + "/claim?email=" + url.QueryEscape(props["email"])
 	} else {
-		err = c.App.DoLogin(w, r, user, "")
+		err = c.App.DoLogin(w, r, user, &model.Device{})
 		if err != nil {
 			err.Translate(c.App.T)
 			c.Err = err

--- a/web/saml.go
+++ b/web/saml.go
@@ -142,7 +142,7 @@ func completeSaml(c *Context, w http.ResponseWriter, r *http.Request) {
 	auditRec.AddMeta("obtained_user_id", user.Id)
 	c.LogAuditWithUserId(user.Id, "obtained user")
 
-	err = c.App.DoLogin(w, r, user, "")
+	err = c.App.DoLogin(w, r, user, &model.Device{})
 	if err != nil {
 		c.Err = err
 		return


### PR DESCRIPTION
Separates PN token, platform and device id.

This required a refactoring that affected login procedures and sending PNs.

This may only be deployed after the client apps are updated with the new API because this is a breaking change.